### PR TITLE
Backend implementation for email validation and preferred email setting

### DIFF
--- a/saltapi/exceptions.py
+++ b/saltapi/exceptions.py
@@ -8,7 +8,9 @@ class AuthenticationError(Exception):
 
 
 class NotFoundError(ValueError):
-    pass
+    def __init__(self, message: str = "Not found"):
+        self.message = message
+        super().__init__(self.message)
 
 
 class ValidationError(ValueError):

--- a/saltapi/exceptions_handling.py
+++ b/saltapi/exceptions_handling.py
@@ -68,7 +68,7 @@ def setup_exception_handler(app: FastAPI) -> None:
 
         log_message(request.method, request.url, exc)
         return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND, content={"message": "Not found"}
+            status_code=status.HTTP_404_NOT_FOUND, content={"message": exc.message}
         )
 
     @app.exception_handler(ValueError)

--- a/saltapi/exceptions_handling.py
+++ b/saltapi/exceptions_handling.py
@@ -68,7 +68,7 @@ def setup_exception_handler(app: FastAPI) -> None:
 
         log_message(request.method, request.url, exc)
         return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND, content={"message": "Not Found"}
+            status_code=status.HTTP_404_NOT_FOUND, content={"message": str(exc)}
         )
 
     @app.exception_handler(ValueError)

--- a/saltapi/exceptions_handling.py
+++ b/saltapi/exceptions_handling.py
@@ -68,7 +68,7 @@ def setup_exception_handler(app: FastAPI) -> None:
 
         log_message(request.method, request.url, exc)
         return JSONResponse(
-            status_code=status.HTTP_404_NOT_FOUND, content={"message": str(exc)}
+            status_code=status.HTTP_404_NOT_FOUND, content={"message": "Not found"}
         )
 
     @app.exception_handler(ValueError)

--- a/saltapi/exceptions_handling.py
+++ b/saltapi/exceptions_handling.py
@@ -77,7 +77,7 @@ def setup_exception_handler(app: FastAPI) -> None:
 
         log_message(request.method, request.url, exc)
         return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST, content={"message":str(exc)}
+            status_code=status.HTTP_400_BAD_REQUEST, content={"message": "Bad Request"}
         )
 
     @app.exception_handler(PydanticValidationError)

--- a/saltapi/exceptions_handling.py
+++ b/saltapi/exceptions_handling.py
@@ -77,7 +77,7 @@ def setup_exception_handler(app: FastAPI) -> None:
 
         log_message(request.method, request.url, exc)
         return JSONResponse(
-            status_code=status.HTTP_400_BAD_REQUEST, content={"message": "Bad Request"}
+            status_code=status.HTTP_400_BAD_REQUEST, content={"message":str(exc)}
         )
 
     @app.exception_handler(PydanticValidationError)

--- a/saltapi/exceptions_handling.py
+++ b/saltapi/exceptions_handling.py
@@ -11,11 +11,11 @@ from pydantic.error_wrappers import ValidationError as PydanticValidationError
 from starlette.datastructures import URL
 
 from saltapi.exceptions import (
+    AuthenticationError,
     AuthorizationError,
     NotFoundError,
-    ValidationError,
-    AuthenticationError,
     SSDAError,
+    ValidationError,
 )
 
 

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -1370,7 +1370,6 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
             SELECT 
                 I.Investigator_Id AS investigator_id,
                 I.Email AS email,
-                I.Institute_Id AS institution_id,
                 CASE 
                     WHEN P.ValidationCode IS NOT NULL THEN TRUE
                     ELSE FALSE

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -1395,7 +1395,7 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
         )
 
     def get_validation_code(self, investigator_id: int) -> str:
-        """Return the latest validation code for an investigator."""
+        """Return validation code for an investigator."""
         stmt = text(
             """
             SELECT ValidationCode

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -655,20 +655,6 @@ WHERE PS.PiptSetting_Name = 'RightLibrarian'
         result = self.connection.execute(stmt, {"username": username})
         return cast(int, result.scalar()) > 0
 
-    def get_all_rights(self, username: str) -> set[str]:
-        stmt = text(
-            """
-            SELECT PS.PiptSetting_Name
-            FROM PiptUser PU
-                JOIN PiptUserSetting PUS ON PU.PiptUser_Id = PUS.PiptUser_Id
-                JOIN PiptSetting PS ON PUS.PiptSetting_Id = PS.PiptSetting_Id
-            WHERE PU.Username = :username
-            AND PUS.Value > 0
-        """
-        )
-        result = self.connection.execute(stmt, {"username": username})
-        return {row[0] for row in result.fetchall()}
-
     @staticmethod
     def get_password_hash(password: str) -> str:
         """Hash a plain text password."""

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -39,13 +39,18 @@ SELECT PU.PiptUser_Id           AS id,
        I2.Institute_Id          AS institution_id,
        I2.Department            AS department,
        PU.Active                AS active,
-       PU.UserVerified          AS user_verified
+       PU.UserVerified          AS user_verified,
+       CASE 
+            WHEN PEV.ValidationCode IS NULL THEN TRUE
+            ELSE FALSE
+        END AS contact_validated
 FROM PiptUser AS PU
          JOIN Investigator I0 ON PU.PiptUser_Id = I0.PiptUser_Id
          JOIN Investigator I1 ON PU.Investigator_Id = I1.Investigator_Id
          JOIN Institute I2 ON I0.Institute_Id = I2.Institute_Id
          JOIN Partner P ON I2.Partner_Id = P.Partner_Id
          JOIN InstituteName I ON I2.InstituteName_Id = I.InstituteName_Id
+         LEFT JOIN PiptEmailValidation PEV ON I0.Investigator_Id = PEV.Investigator_Id
 """
 
     def _get(self, rows: Any) -> Optional[User]:
@@ -71,6 +76,7 @@ FROM PiptUser AS PU
                     "department": row.department,
                     "partner_code": row.partner_code,
                     "partner_name": row.partner_name,
+                    "contact_validated": row.contact_validated,
                 }
             )
         if user:
@@ -1363,8 +1369,6 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
             """
             SELECT 
                 I.Investigator_Id AS investigator_id,
-                I.FirstName AS given_name,
-                I.Surname AS family_name,
                 I.Email AS email,
                 I.Institute_Id AS institution_id,
                 CASE 

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -11,7 +11,7 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.exc import IntegrityError, NoResultFound
 
 from saltapi.exceptions import NotFoundError, ResourceExistsError, ValidationError
-from saltapi.service.user import Role, User, UserRight, RIGHT_DB_NAMES
+from saltapi.service.user import RIGHT_DB_NAMES, Role, User, UserRight
 
 pwd_context = CryptContext(
     schemes=["bcrypt", "md5_crypt"], default="bcrypt", deprecated="auto"

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -1475,3 +1475,31 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
         self.connection.execute(
             stmt, {"user_id": user_id, "right_name": right, "value": int(grant)}
         )
+
+    def get_user_email_for_investigator(
+        self, user_id: int, investigator_id: int
+    ) -> Optional[Dict[str, Any]]:
+        stmt = text(
+            """
+            SELECT 
+                I.Investigator_Id AS investigator_id,
+                I.Email AS email,
+                CASE 
+                    WHEN P.ValidationCode IS NULL THEN TRUE
+                    ELSE FALSE
+                END AS is_validated
+            FROM Investigator I
+            LEFT JOIN PiptEmailValidation P
+                ON P.Investigator_Id = I.Investigator_Id
+            WHERE
+                I.PiptUser_Id = :user_id
+                AND I.Investigator_Id = :investigator_id
+            """
+        )
+
+        result = self.connection.execute(
+            stmt,
+            {"user_id": user_id, "investigator_id": investigator_id},
+        ).fetchone()
+
+        return dict(result) if result else None

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -1503,3 +1503,21 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
         ).fetchone()
 
         return dict(result) if result else None
+
+    def get_preferred_contact(self, user_id: int) -> dict | None:
+        stmt = text(
+            """
+            SELECT 
+                PU.PiptUser_Id      AS user_id,
+                I.Email             AS preferred_email,
+                I.Investigator_Id   AS investigator_id
+            FROM PiptUser AS PU
+            JOIN Investigator I
+                ON PU.Investigator_Id = I.Investigator_Id
+            WHERE PU.PiptUser_Id = :user_id
+            """
+        )
+
+        result = self.connection.execute(stmt, {"user_id": user_id}).fetchone()
+
+        return dict(result) if result else None

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -1476,7 +1476,7 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
             stmt, {"user_id": user_id, "right_name": right, "value": int(grant)}
         )
 
-    def get_user_email_for_investigator(
+    def get_users_contact(
         self, user_id: int, investigator_id: int
     ) -> Optional[Dict[str, Any]]:
         stmt = text(

--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -1413,9 +1413,24 @@ WHERE PiptSetting_Id = 32     # ID for PiptSetting_Name = 'GravitationalWaveProp
     def clear_validation_code(self, investigator_id: int) -> None:
         stmt = text(
             """
-            UPDATE PiptEmailValidation
-            SET ValidationCode = NULL
+            DELETE FROM PiptEmailValidation
             WHERE Investigator_Id = :investigator_id
         """
         )
         self.connection.execute(stmt, {"investigator_id": investigator_id})
+
+    def get_investigator_by_validation_code(
+        self, validation_code: str
+    ) -> Optional[Dict[str, Any]]:
+        stmt = text(
+            """
+            SELECT I.Investigator_Id, I.PiptUser_Id, P.ValidationCode
+            FROM Investigator I
+            LEFT JOIN PiptEmailValidation P ON P.Investigator_Id = I.Investigator_Id
+            WHERE P.ValidationCode = :validation_code
+        """
+        )
+        result = self.connection.execute(
+            stmt, {"validation_code": validation_code}
+        ).fetchone()
+        return dict(result) if result else None

--- a/saltapi/service/mail_service.py
+++ b/saltapi/service/mail_service.py
@@ -17,7 +17,7 @@ class MailService:
                 "variable SMTP_SERVER to define the server."
             )
             return
-        with smtplib.SMTP(settings.smtp_server) as smtp_obj:
+        with smtplib.SMTP(settings.smtp_server, settings.smtp_port) as smtp_obj:
             if settings.smtp_username and settings.smtp_password:
                 smtp_obj.starttls()
                 smtp_obj.login(settings.smtp_username, settings.smtp_password)

--- a/saltapi/service/permission_service.py
+++ b/saltapi/service/permission_service.py
@@ -11,8 +11,10 @@ from saltapi.repository.user_repository import UserRepository
 from saltapi.repository.utils import Utils
 from saltapi.service.user import Role, User
 from saltapi.settings import get_settings
-from saltapi.web.schema.proposal import (ProposalStatusValue,
-                                         ProprietaryPeriodUpdateRequest)
+from saltapi.web.schema.proposal import (
+    ProposalStatusValue,
+    ProprietaryPeriodUpdateRequest,
+)
 
 
 class PermissionService:
@@ -623,3 +625,13 @@ class PermissionService:
         if self.check_user_has_role(user, Role.ADMINISTRATOR) or user_id == user.id:
             return
         raise AuthorizationError("You are not allowed view the subscriptions.")
+
+    def check_user_access(self, user_id, user):
+        """
+        Ensure that the logged-in user is performing an action only on their account.
+        """
+        if user_id == user.id:
+            return
+        raise AuthorizationError(
+            "You are not allowed to perform this action on another user's account."
+        )

--- a/saltapi/service/permission_service.py
+++ b/saltapi/service/permission_service.py
@@ -626,7 +626,7 @@ class PermissionService:
             return
         raise AuthorizationError("You are not allowed view the subscriptions.")
 
-    def check_user_access(self, user_id, user):
+    def check_user_is_self(self, user_id, user):
         """
         Ensure that the logged-in user is performing an action only on their account.
         """

--- a/saltapi/service/permission_service.py
+++ b/saltapi/service/permission_service.py
@@ -643,16 +643,16 @@ class PermissionService:
         Check that the investigator email exists and has been validated
         before allowing it to be set as the preferred contact.
         """
-        contact = self.user_repository.get_user_email_for_investigator(
+        contact = self.user_repository.get_users_contact(
             user_id, investigator_id
         )
 
         if not contact:
             raise ValidationError(
-                f"No email found for investigator {investigator_id}."
+                f"No contact details found for investigator {investigator_id}."
             )
 
         if not contact["is_validated"]:
             raise ValidationError(
-                "You cannot set this email as preferred until it's validated."
+                "You cannot set this contact as preferred until it has been validated."
             )

--- a/saltapi/service/permission_service.py
+++ b/saltapi/service/permission_service.py
@@ -635,3 +635,24 @@ class PermissionService:
         raise AuthorizationError(
             "You are not allowed to perform this action on another user's account."
         )
+
+    def check_permission_to_set_preferred_contact(
+        self, user_id: int, investigator_id: int
+    ) -> None:
+        """
+        Check that the investigator email exists and has been validated
+        before allowing it to be set as the preferred contact.
+        """
+        contact = self.user_repository.get_user_email_for_investigator(
+            user_id, investigator_id
+        )
+
+        if not contact:
+            raise ValidationError(
+                f"No email found for investigator {investigator_id}."
+            )
+
+        if not contact["is_validated"]:
+            raise ValidationError(
+                "You cannot set this email as preferred until it's validated."
+            )

--- a/saltapi/service/user.py
+++ b/saltapi/service/user.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from enum import Enum
 from typing import Dict, List, Optional
+
 from saltapi.web.schema.user import UserRight
 
 

--- a/saltapi/service/user.py
+++ b/saltapi/service/user.py
@@ -50,6 +50,7 @@ class Institution:
     department: Optional[str]
     partner_code: str
 
+
 @dataclass()
 class UserDemographics:
     legal_status: str

--- a/saltapi/service/user_service.py
+++ b/saltapi/service/user_service.py
@@ -292,6 +292,34 @@ SALT Team
         """
         return self.repository.get_user_emails(user_id)
 
+    def set_preferred_email(self, user_id: int, email: str, institution_id: int) -> str:
+        """
+        Sets a user's preferred email.
+        """
+        emails = self.get_emails(user_id)
+
+        matching_email = next(
+            (
+                e
+                for e in emails
+                if e["email"] == email and e["institution_id"] == institution_id
+            ),
+            None,
+        )
+        if not matching_email:
+            raise NotFoundError(
+                f"No email '{email}' found for institution {institution_id}."
+            )
+        if matching_email["pending"] != 0:
+            raise ValidationError(
+                "You cannot set this email as preferred until it's validated."
+            )
+
+        investigator_id = matching_email["investigator_id"]
+        self.repository.set_preferred_contact(user_id, investigator_id)
+
+        return f"Preferred email successfully set to {email}"
+
     def get_email_validation_code(self, investigator_id: int) -> str:
         """Get validation code for a certain investigator id"""
 

--- a/saltapi/service/user_service.py
+++ b/saltapi/service/user_service.py
@@ -290,26 +290,18 @@ SALT Team
     def get_subscriptions(self, user_id: int) -> List[Dict[str, Any]]:
         return self.repository.get_subscriptions(user_id)
 
-    def set_preferred_email(
-        self, user_id: int, email: str, investigator_id: int
-    ) -> str:
+    def set_preferred_contact(self, user_id: int, investigator_id: int) -> str:
         """
-        Sets a user's preferred email.
+        Sets a user's preferred contact.
         """
         emails = self.repository.get_user_emails(user_id)
         matching_email = next(
-            (
-                e
-                for e in emails
-                if e["email"] == email and e["investigator_id"] == investigator_id
-            ),
+            (e for e in emails if e["investigator_id"] == investigator_id),
             None,
         )
 
         if not matching_email:
-            raise NotFoundError(
-                f"No email '{email}' found for investigator {investigator_id}."
-            )
+            raise ValidationError(f"No email found for investigator {investigator_id}.")
 
         if matching_email["pending"] != 0:
             raise ValidationError(
@@ -317,7 +309,7 @@ SALT Team
             )
 
         self.repository.set_preferred_contact(user_id, investigator_id)
-        return f"Preferred email successfully set to {email}"
+        return f"Preferred contact is successfully set to {matching_email['email']}"
 
     def get_email_validation_code(self, investigator_id: int) -> str:
         """Get validation code for a certain investigator id"""

--- a/saltapi/service/user_service.py
+++ b/saltapi/service/user_service.py
@@ -347,10 +347,10 @@ SALT Team
 
         contact = next((c for c in contacts if c["email"] == email), None)
         if not contact:
-            raise ValueError(f"No contact found with email {email}")
+            raise NotFoundError(f"No contact found with email {email}")
 
         if contact.get("pending") != 1:
-            raise ValueError(f"The email {email} has already been validated.")
+            raise ValidationError(f"The email {email} has already been validated.")
 
         investigator_id = contact["investigator_id"]
 

--- a/saltapi/service/user_service.py
+++ b/saltapi/service/user_service.py
@@ -294,22 +294,13 @@ SALT Team
         """
         Sets a user's preferred contact.
         """
-        emails = self.repository.get_user_emails(user_id)
-        matching_email = next(
-            (e for e in emails if e["investigator_id"] == investigator_id),
-            None,
-        )
-
-        if not matching_email:
-            raise ValidationError(f"No email found for investigator {investigator_id}.")
-
-        if matching_email["pending"] != 0:
+        preferred = self.repository.get_preferred_contact(user_id)
+        if preferred and preferred["investigator_id"] == investigator_id:
             raise ValidationError(
-                "You cannot set this email as preferred until it's validated."
+                "This email is already set as your preferred contact."
             )
-
         self.repository.set_preferred_contact(user_id, investigator_id)
-        return f"Preferred contact is successfully set to {matching_email['email']}"
+        return f"Preferred contact is successfully set"
 
     def get_email_validation_code(self, investigator_id: int) -> str:
         """Get validation code for a certain investigator id"""

--- a/saltapi/service/user_service.py
+++ b/saltapi/service/user_service.py
@@ -286,12 +286,6 @@ SALT Team
     def get_subscriptions(self, user_id: int) -> List[Dict[str, Any]]:
         return self.repository.get_subscriptions(user_id)
 
-    def get_emails(self, user_id: int) -> List[Dict[str, Any]]:
-        """
-        Get all emails for a given PiptUser, along with pending status.
-        """
-        return self.repository.get_user_emails(user_id)
-
     def set_preferred_email(self, user_id: int, email: str, institution_id: int) -> str:
         """
         Sets a user's preferred email.
@@ -360,8 +354,8 @@ SALT Team
         affected_user = self.get_user(user_id)
 
         contact_info = {
-            "given_name": contact["given_name"],
-            "family_name": contact["family_name"],
+            "given_name": affected_user.given_name,
+            "family_name": affected_user.family_name,
             "email": contact["email"],
             "institution_id": contact["institution_id"],
         }

--- a/saltapi/service/user_service.py
+++ b/saltapi/service/user_service.py
@@ -91,6 +91,10 @@ SALT Team
                 raise ValidationError("Race is missing.")
             if user_details["has_phd"] and not user_details["year_of_phd_completion"]:
                 raise ValidationError("Year of completing PhD is missing.")
+            if not user_details["has_phd"] and user_details["year_of_phd_completion"]:
+                raise ValidationError(
+                    "A PhD year cannot be provided if the user does not have a PhD."
+                )
 
     def create_user(self, user: NewUserDetails) -> int:
         if self._does_user_exist(user.username):

--- a/saltapi/settings.py
+++ b/saltapi/settings.py
@@ -69,6 +69,9 @@ class Settings(BaseSettings):
     # Password for the SMTP server
     smtp_password: Optional[str]
 
+    # SMTP port for sending emails
+    smtp_port: int = 0
+
     # Directory containing the jar file MappingService.jar for mapping proposals to the
     # database
     mapping_tool_dir: DirectoryPath

--- a/saltapi/settings.py
+++ b/saltapi/settings.py
@@ -70,7 +70,7 @@ class Settings(BaseSettings):
     smtp_password: Optional[str]
 
     # SMTP port for sending emails
-    smtp_port: int = 0
+    smtp_port: int
 
     # Directory containing the jar file MappingService.jar for mapping proposals to the
     # database

--- a/saltapi/web/api/users.py
+++ b/saltapi/web/api/users.py
@@ -510,29 +510,6 @@ def get_subscriptions(
         return user_service.get_subscriptions(user_id)
 
 
-@router.get(
-    "/emails/{user_id}",
-    response_model=List[Dict[str, Any]],
-    summary="Get all emails for a user",
-)
-def get_user_emails(
-    user_id: int = Path(..., title="PiptUser ID"),
-    user=Depends(get_current_user),
-):
-    """
-    Returns all email addresses for a user along with their verification status (pending or not).
-    """
-    with UnitOfWork() as unit_of_work:
-        permission_service = services.permission_service(unit_of_work.connection)
-        permission_service.check_permission_to_validate_user(user_id, user)
-        user_service = services.user_service(unit_of_work.connection)
-        try:
-            emails = user_service.get_emails(user_id)
-        except Exception as e:
-            raise HTTPException(status_code=404, detail=str(e))
-        return emails
-
-
 @router.post("/validate-email", summary="Validate email using validation code")
 def validate_email(
     validation_code: str = Query(..., description="Validation code from email"),

--- a/saltapi/web/api/users.py
+++ b/saltapi/web/api/users.py
@@ -533,7 +533,7 @@ def validate_email(
             )
             if not validation:
                 raise ValidationError("Invalid validation code.")
-            permission_service.check_user_access(validation["PiptUser_Id"], user)
+            permission_service.check_user_is_self(validation["PiptUser_Id"], user)
             message = user_service.validate_email(validation_code)
             unit_of_work.commit()
             return Message(message=message)
@@ -567,10 +567,10 @@ def resend_verification_email_for_contact(
     with UnitOfWork() as unit_of_work:
         user_service = services.user_service(unit_of_work.connection)
         permission_service = services.permission_service(unit_of_work.connection)
-        permission_service.check_user_access(user_id, user)
+        permission_service.check_user_is_self(user_id, user)
         try:
             user_service.resend_verification_email_for_contact(user_id, email)
-        except ValueError as e:
+        except Exception as e:
             raise HTTPException(status_code=400, detail=str(e))
         unit_of_work.commit()
         return Message(message=f"Verification email resent successfully to {email}")
@@ -596,7 +596,7 @@ def set_preferred_email(
     with UnitOfWork() as unit_of_work:
         permission_service = services.permission_service(unit_of_work.connection)
         user_service = services.user_service(unit_of_work.connection)
-        permission_service.check_user_access(user_id, user)
+        permission_service.check_user_is_self(user_id, user)
         try:
             message = user_service.set_preferred_email(
                 user_id=user_id,

--- a/saltapi/web/api/users.py
+++ b/saltapi/web/api/users.py
@@ -578,6 +578,9 @@ def set_preferred_contact(
         permission_service = services.permission_service(unit_of_work.connection)
         user_service = services.user_service(unit_of_work.connection)
         permission_service.check_user_is_self(user_id, user)
+        permission_service.check_permission_to_set_preferred_contact(
+            user_id, investigator_id
+        )
         message = user_service.set_preferred_contact(
             user_id=user_id,
             investigator_id=investigator_id,

--- a/saltapi/web/api/users.py
+++ b/saltapi/web/api/users.py
@@ -18,7 +18,6 @@ from saltapi.web.schema.user import (
     NewUserDetails,
     PasswordResetRequest,
     PasswordUpdate,
-    PreferredEmailRequest,
     ProposalPermission,
     Subscription,
     User,
@@ -559,30 +558,29 @@ def resend_verification_email_for_contact(
 
 
 @router.patch(
-    "/{user_id}/set-preferred-email",
-    summary="Set preferred email for a validated contact",
+    "/{user_id}/set-preferred-contact/{investigator_id}",
+    summary="Set preferred contact for a validated email",
     response_model=Message,
 )
-def set_preferred_email(
+def set_preferred_contact(
     user_id: int = Path(
         ..., title="User id", description="User ID of the current user"
     ),
-    preferred_email: PreferredEmailRequest = Body(
-        ..., description="Preferred email data"
+    investigator_id: int = Path(
+        ..., title="Investigator ID", description="The email address investigator id."
     ),
     user: _User = Depends(get_current_user),
 ) -> Message:
     """
-    Set the preferred email for the logged-in user.
+    Set the preferred contact for the logged-in user.
     """
     with UnitOfWork() as unit_of_work:
         permission_service = services.permission_service(unit_of_work.connection)
         user_service = services.user_service(unit_of_work.connection)
         permission_service.check_user_is_self(user_id, user)
-        message = user_service.set_preferred_email(
+        message = user_service.set_preferred_contact(
             user_id=user_id,
-            email=preferred_email.email,
-            investigator_id=preferred_email.investigator_id,
+            investigator_id=investigator_id,
         )
         unit_of_work.commit()
         return Message(message=message)

--- a/saltapi/web/api/users.py
+++ b/saltapi/web/api/users.py
@@ -568,10 +568,7 @@ def resend_verification_email_for_contact(
         user_service = services.user_service(unit_of_work.connection)
         permission_service = services.permission_service(unit_of_work.connection)
         permission_service.check_user_is_self(user_id, user)
-        try:
-            user_service.resend_verification_email_for_contact(user_id, email)
-        except Exception as e:
-            raise HTTPException(status_code=400, detail=str(e))
+        user_service.resend_verification_email_for_contact(user_id, email)
         unit_of_work.commit()
         return Message(message=f"Verification email resent successfully to {email}")
 
@@ -597,13 +594,10 @@ def set_preferred_email(
         permission_service = services.permission_service(unit_of_work.connection)
         user_service = services.user_service(unit_of_work.connection)
         permission_service.check_user_is_self(user_id, user)
-        try:
-            message = user_service.set_preferred_email(
-                user_id=user_id,
-                email=preferred_email.email,
-                investigator_id=preferred_email.investigator_id,
-            )
-            unit_of_work.commit()
-            return Message(message=message)
-        except Exception as e:
-            raise HTTPException(status_code=500, detail=str(e))
+        message = user_service.set_preferred_email(
+            user_id=user_id,
+            email=preferred_email.email,
+            investigator_id=preferred_email.investigator_id,
+        )
+        unit_of_work.commit()
+        return Message(message=message)

--- a/saltapi/web/schema/institution.py
+++ b/saltapi/web/schema/institution.py
@@ -35,10 +35,17 @@ class UserInstitution(Institution):
         title="Contact",
         description="The user's email address for this institution",
     )
-    contact_validated : bool = Field(
+    is_contact_validated: bool = Field(
         ...,
         title="Contact Validated",
         description="Indicates whether this email has been validated",
+    )
+    investigator_id: int = Field(
+        ...,
+        title="Investigator ID",
+        description=(
+            "ID for the investigator record associated with this email and institution"
+        ),
     )
 
 

--- a/saltapi/web/schema/institution.py
+++ b/saltapi/web/schema/institution.py
@@ -35,6 +35,11 @@ class UserInstitution(Institution):
         title="Contact",
         description="The user's email address for this institution",
     )
+    contact_validated : bool = Field(
+        ...,
+        title="Contact Validated",
+        description="Indicates whether this email has been validated",
+    )
 
 
 class NewInstitutionDetails(BaseModel):

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -228,7 +228,7 @@ class Subscription(BaseModel):
     )
 
 
-class EmailValidationResponse(BaseModel):
+class MessageResponse(BaseModel):
     """Response after validating a user's email."""
 
     message: str = Field(

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -230,10 +230,11 @@ class Subscription(BaseModel):
 
 class EmailValidationResponse(BaseModel):
     """Response after validating a user's email."""
+
     message: str = Field(
         ...,
         title="Email Validation Message",
-        description=
+        description=(
             "Confirmation message indicating the result of the email validation. "
-        )
-
+        ),
+    )

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -228,13 +228,8 @@ class Subscription(BaseModel):
     )
 
 
-class MessageResponse(BaseModel):
-    """Response after validating a user's email."""
-
-    message: str = Field(
-        ...,
-        title="Email Validation Message",
-        description=(
-            "Confirmation message indicating the result of the email validation. "
-        ),
+class PreferredEmailRequest(BaseModel):
+    email: str = Field(..., title="Email address", description="The email address.")
+    investigator_id: int = Field(
+        ..., title="Investigator ID", description="The email address."
     )

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -43,24 +43,6 @@ class UserListItem(FullName):
     id: int = Field(..., title="User id", description="User id.")
     username: str = Field(..., title="Username", description="The username.")
 
-
-class User(FullName):
-    """User details."""
-
-    id: int = Field(..., title="User id", description="User id.")
-    email: EmailStr = Field(..., title="Email address", description="Email address")
-    username: str = Field(..., title="Username", description="Username.")
-    roles: List[UserRole] = Field(..., title="User roles", description="User roles.")
-    affiliations: List[UserInstitution] = Field(
-        ..., title="Affiliation", description="Affiliation of the user"
-    )
-    demographics: Optional[UserDemographics] = Field(
-        None,
-        title="User Demographics",
-        description="Information about user's legal status in South Africa",
-    )
-
-
 class LegalStatus(str, Enum):
     """
     South African legal status.
@@ -242,7 +224,6 @@ class Subscription(BaseModel):
     is_subscribed: bool = Field(
         ..., title="Is subscribed", description="Whether the user is subscribed"
     )
-
 
 class PreferredEmailRequest(BaseModel):
     email: str = Field(..., title="Email address", description="The email address.")

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -43,6 +43,7 @@ class UserListItem(FullName):
     id: int = Field(..., title="User id", description="User id.")
     username: str = Field(..., title="Username", description="The username.")
 
+
 class LegalStatus(str, Enum):
     """
     South African legal status.
@@ -84,7 +85,7 @@ class User(FullName):
     demographics: Optional[UserDemographics] = Field(
         None,
         title="User Demographics",
-        description="Information about user's legal status in South Africa"
+        description="Information about user's legal status in South Africa",
     )
 
 
@@ -223,12 +224,6 @@ class Subscription(BaseModel):
     )
     is_subscribed: bool = Field(
         ..., title="Is subscribed", description="Whether the user is subscribed"
-    )
-
-class PreferredEmailRequest(BaseModel):
-    email: str = Field(..., title="Email address", description="The email address.")
-    investigator_id: int = Field(
-        ..., title="Investigator ID", description="The email address."
     )
 
 

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -226,3 +226,14 @@ class Subscription(BaseModel):
     is_subscribed: bool = Field(
         ..., title="Is subscribed", description="Whether the user is subscribed"
     )
+
+
+class EmailValidationResponse(BaseModel):
+    """Response after validating a user's email."""
+    message: str = Field(
+        ...,
+        title="Email Validation Message",
+        description=
+            "Confirmation message indicating the result of the email validation. "
+        )
+

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -58,7 +58,7 @@ class User(FullName):
     demographics: Optional[UserDemographics] = Field(
         None,
         title="User Demographics",
-        description="Information about user's legal status in South Africa"
+        description="Information about user's legal status in South Africa",
     )
 
 


### PR DESCRIPTION
This MR introduces the backend functionality to enable users to set their preferred email address only after it has been validated. Changes include:

- Email validation link generation when adding a new contact
- Resend validation endpoint
- Email validation endpoint
- Set preferred email endpoint

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/salt-api/382)
<!-- Reviewable:end -->
