### PR TITLE
Fix user update issue with 'Other' legal status

### DIFF
--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -303,8 +303,8 @@ SELECT  SL.SouthAfricanLegalStatus  AS legal_status,
         US.YearOfPhD                      AS year_of_phd
 FROM UserStatistics US
     JOIN SouthAfricanLegalStatus SL ON US.SouthAfricanLegalStatus_Id = SL.SouthAfricanLegalStatus_Id
-    JOIN Race R ON US.Race_Id = R.Race_Id
-    JOIN Gender G ON US.Gender_Id = G.Gender_Id
+    LEFT JOIN Race R ON US.Race_Id = R.Race_Id
+    LEFT JOIN Gender G ON US.Gender_Id = G.Gender_Id
 WHERE US.PiptUser_Id = :user_id
                 """
         )


### PR DESCRIPTION
This MR fixes a minor bug where users with the “Other” legal status could not be updated because their demographics row was being dropped by the query. This ensures that users with missing demographics fields like gender or race set to NULL are still returned.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/salt-api/385)
<!-- Reviewable:end -->
