### PR TITLE
Remove email from user update endpoint and isolate email changes to add contact flow

### DIFF
--- a/saltapi/repository/user_repository.py
+++ b/saltapi/repository/user_repository.py
@@ -269,18 +269,10 @@ WHERE Investigator_Id = :investigator_id
         Updates a user's details.
 
         If the user id does not exist, a NotFoundError is raised.
-        If the email exists already and belongs to another user, a ValueError is raised.
 
         """
         if not self.is_existing_user_id(user_id):
             raise NotFoundError(f"Unknown user id: {user_id}")
-
-        user = self.get_by_email(user_update["email"])
-        if user is not None:
-            if user.id != user_id:
-                raise ResourceExistsError(
-                    f"The email {user_update['email']} exists already."
-                )
 
         if user_update["password"]:
             self.update_password(user_id, user_update["password"])
@@ -705,8 +697,7 @@ WHERE PiptUser_Id = :user_id
             """
 UPDATE Investigator
 SET FirstName = :given_name,
-    Surname   = :family_name,
-    Email     = :email
+    Surname   = :family_name
 WHERE Investigator_Id =
       (SELECT Investigator_Id FROM PiptUser WHERE PiptUser_Id = :user_id)
              """
@@ -719,16 +710,10 @@ WHERE Investigator_Id =
                     "user_id": user_id,
                     "given_name": user_update["given_name"],
                     "family_name": user_update["family_name"],
-                    "email": user_update["email"],
                 },
             )
         except NoResultFound:
             raise NotFoundError(f"No such user id: {user_id}")
-        except IntegrityError:
-            raise ValidationError(
-                f"There are contact details with this email address and institute"
-                f" already."
-            )
 
     @staticmethod
     def get_new_password_hash(password: str) -> str:

--- a/saltapi/service/user.py
+++ b/saltapi/service/user.py
@@ -104,7 +104,9 @@ class UserDetails(UserDemographics):
 
 
 @dataclass(frozen=True)
-class UserUpdate(UserDetails):
+class UserUpdate(UserDemographics):
+    given_name: str
+    family_name: str
     password: Optional[str]
 
 

--- a/saltapi/web/api/users.py
+++ b/saltapi/web/api/users.py
@@ -195,7 +195,6 @@ def update_user(
         permission_service = services.permission_service(unit_of_work.connection)
         permission_service.check_permission_to_update_user(user, user_id)
         _user_update = _UserUpdate(
-            email=user_update.email,
             family_name=user_update.family_name,
             given_name=user_update.given_name,
             password=user_update.password,

--- a/saltapi/web/schema/user.py
+++ b/saltapi/web/schema/user.py
@@ -126,11 +126,26 @@ class NewUserDetails(BaseUserDetails):
     )
 
 
-class UserUpdate(BaseUserDetails):
+class UserUpdate(BaseModel):
     """
     Details for updating a user.
     """
 
+    given_name: str = Field(..., title="Given name", description="Given name.")
+    family_name: str = Field(..., title="Family name", description="Family name.")
+    legal_status: LegalStatus = Field(
+        ..., title="Legal status", description="The legal status in South Africa"
+    )
+    gender: Optional[str] = Field(..., title="Gender", description="Gender.")
+    race: Optional[str] = Field(..., title="Race", description="Race.")
+    has_phd: Optional[bool] = Field(
+        ..., title="PhD", description="Does the user has a PhD?"
+    )
+    year_of_phd_completion: Optional[int] = Field(
+        None,
+        title="Year of PhD degree completion",
+        description="The year the PhD degree was completed",
+    )
     password: Optional[str] = Field(None, title="Password", description="Password.")
 
 


### PR DESCRIPTION
This PR updates the backend so that a user's email can no longer be updated through user update. This is to ensure that the email that is set as preferred has been validated.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/salt-api/395)
<!-- Reviewable:end -->
