### PR TITLE
Handle missing department

### DIFF
--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -990,8 +990,13 @@ ORDER BY P.Partner_Code, IName.InstituteName_Name, I.Department
                     "name": row.partner_name,
                     "institutes": [],
                 }
+            department = row.department
+            if department is not None:
+                department = department.strip()
+            if department == "":
+                department = None
             partners_dict[partner_code]["institutes"].append(
-                {"name": row.institute_name, "department": row.department}
+                {"name": row.institute_name, "department": department}
             )
 
         # Turn the dictionary into a list and sort the result. The institutes are


### PR DESCRIPTION
If an institute has no department, its database entry may have a string with a single space for the Department column value. This should be replaced with null in the data returned by the partners endpoint.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/salt-api/402)
<!-- Reviewable:end -->
