### PR TITLE
Proposals query bottleneck

### DIFF
--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -914,7 +914,8 @@ class PiptRepository:
         order_by = f"Proposal.Proposal_Id {'DESC' if descending else 'ASC'}"
         sql += f" ORDER BY {order_by}"
         if limit is not None:
-            sql += " LIMIT {limit}"
+            sql += " LIMIT :limit"
+            params["limit"] = limit
 
         result = self.connection.execute(text(sql), params)
         proposals = [dict(row) for row in result.mappings()]

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -842,7 +842,7 @@ class PiptRepository:
         user: User,
         phase: Optional[int] = None,
         limit: Optional[int] = None,
-        descending: bool = False,
+        descending: bool = True,
     ) -> List[Dict[str, Any]]:
         """
         Fetch proposals with optional filters for phase and proposal_code.

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -837,32 +837,6 @@ class PiptRepository:
 
         return block_visits
 
-    def _get_proposal_query(self) -> str:
-        return """
-            SELECT Proposal.Proposal_Id,
-                Proposal.ProposalCode_Id,
-                ProposalCode.Proposal_Code,
-                Proposal.Current,
-                Proposal.Semester_Id,
-                Proposal.TotalReqTime,
-                Proposal.Phase,
-                Proposal.Submission,
-                UNIX_TIMESTAMP(Proposal.SubmissionDate) AS submission_timestamp,
-                Proposal.OverheadTime,
-                PULead.Username AS leader_username,
-                PUCont.Username AS contact_username
-            FROM Proposal
-            JOIN ProposalContact ON Proposal.ProposalCode_Id = ProposalContact.ProposalCode_Id
-            JOIN ProposalCode ON Proposal.ProposalCode_Id = ProposalCode.ProposalCode_Id
-            JOIN ProposalGeneralInfo ON Proposal.ProposalCode_Id = ProposalGeneralInfo.ProposalCode_Id
-            JOIN ProposalStatus ON ProposalGeneralInfo.ProposalStatus_Id = ProposalStatus.ProposalStatus_Id
-            JOIN Semester ON Proposal.Semester_Id = Semester.Semester_Id
-            JOIN Investigator ILead ON ILead.Investigator_Id = ProposalContact.Leader_Id
-            JOIN Investigator ICont ON ICont.Investigator_Id = ProposalContact.Contact_Id
-            JOIN PiptUser PULead ON PULead.PiptUser_Id = ILead.PiptUser_Id
-            JOIN PiptUser PUCont ON PUCont.PiptUser_Id = ICont.PiptUser_Id
-        """
-
     def get_proposals(
         self,
         user: User,
@@ -874,7 +848,7 @@ class PiptRepository:
         Fetch proposals with optional filters for phase and proposal_code.
         """
 
-        where_clauses = []
+        where_clauses = ["Proposal.Current = 1"]
         params: Dict[str, Any] = {}
 
         username = user.username
@@ -893,7 +867,25 @@ class PiptRepository:
             )
             params["accepted"] = "Accepted"
 
-        sql = self._get_proposal_query()
+        sql = """
+            SELECT Proposal.Proposal_Id AS Proposal_Id,
+                ProposalCode.Proposal_Code AS Proposal_Code,
+                ProposalText.Title AS Title,
+                ILead.Surname AS PI_Surname,
+                PULead.Username AS Leader_Username,
+                PUCont.Username AS Contact_Username
+            FROM Proposal
+            JOIN ProposalContact ON Proposal.ProposalCode_Id = ProposalContact.ProposalCode_Id
+            JOIN ProposalCode ON Proposal.ProposalCode_Id = ProposalCode.ProposalCode_Id
+            JOIN ProposalGeneralInfo ON Proposal.ProposalCode_Id = ProposalGeneralInfo.ProposalCode_Id
+            JOIN ProposalStatus ON ProposalGeneralInfo.ProposalStatus_Id = ProposalStatus.ProposalStatus_Id
+            JOIN ProposalText ON Proposal.ProposalCode_Id = ProposalText.ProposalCode_Id
+            JOIN Semester ON Proposal.Semester_Id = Semester.Semester_Id
+            JOIN Investigator ILead ON ILead.Investigator_Id = ProposalContact.Leader_Id
+            JOIN Investigator ICont ON ICont.Investigator_Id = ProposalContact.Contact_Id
+            JOIN PiptUser PULead ON PULead.PiptUser_Id = ILead.PiptUser_Id
+            JOIN PiptUser PUCont ON PUCont.PiptUser_Id = ICont.PiptUser_Id
+        """
 
         if not can_see_all:
             sql += """
@@ -911,21 +903,12 @@ class PiptRepository:
             sql += f" WHERE {where_clause}"
 
         order_by = f"Proposal.Proposal_Id {'DESC' if descending else 'ASC'}"
-        sql += f" ORDER BY {order_by} LIMIT {limit}"
+        sql += f" ORDER BY {order_by}"
+        if limit is not None:
+            sql += " LIMIT {limit}"
 
         result = self.connection.execute(text(sql), params)
         proposals = [dict(row) for row in result.mappings()]
-
-        pi_sql = """
-            SELECT DISTINCT p.Proposal_Id AS proposal_id, i.Surname AS surname
-            FROM Investigator AS i
-            JOIN ProposalContact AS pc ON i.Investigator_Id = pc.Leader_Id
-            JOIN Proposal AS p ON pc.ProposalCode_Id = p.ProposalCode_Id
-        """
-        pi_result = self.connection.execute(text(pi_sql))
-        principal_investigator = {
-            row.proposal_id: row.surname for row in pi_result.mappings()
-        }
 
         # Build final proposal list, remove duplicates by Proposal_Code
         proposals_list = []
@@ -937,22 +920,19 @@ class PiptRepository:
                 continue
             seen_codes.add(code)
 
-            full_proposal = self.proposal_repository.get(code)
             editable = can_edit_all or username in [
-                proposal["leader_username"],
-                proposal["contact_username"],
+                proposal["Leader_Username"],
+                proposal["Contact_Username"],
             ]
+            editable = False
             proposals_list.append(
                 {
                     "proposal_id": proposal["Proposal_Id"],
                     "proposal_code": code,
-                    "title": full_proposal["general_info"]["title"],
-                    "principal_investigator": principal_investigator.get(
-                        proposal["Proposal_Id"]
-                    ),
-                    "semester": full_proposal["semester"],
+                    "title": proposal["Title"],
+                    "principal_investigator": proposal["PI_Surname"],
                     "editable": editable,
-                    "proposal_file": full_proposal["proposal_file"],
+                    "proposal_file": ProposalRepository.proposal_file_url(code),
                 }
             )
         return proposals_list

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -840,7 +840,7 @@ class PiptRepository:
     def get_proposals(
         self,
         user: User,
-        phase: Optional[int] = None,
+        phase: int,
         limit: Optional[int] = None,
         descending: bool = True,
     ) -> List[Dict[str, Any]]:

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -841,7 +841,7 @@ class PiptRepository:
         self,
         user: User,
         phase: Optional[int] = None,
-        limit: int = 250,
+        limit: Optional[int] = None,
         descending: bool = False,
     ) -> List[Dict[str, Any]]:
         """

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -934,7 +934,6 @@ class PiptRepository:
                 proposal["Leader_Username"],
                 proposal["Contact_Username"],
             ]
-            editable = False
             proposals_list.append(
                 {
                     "proposal_id": proposal["Proposal_Id"],

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -911,7 +911,7 @@ class PiptRepository:
         if where_clause:
             sql += f" WHERE {where_clause}"
 
-        order_by = f"Proposal.Proposal_Id {'DESC' if descending else 'ASC'}"
+        order_by = f"ProposalCode.Proposal_Code {'DESC' if descending else 'ASC'}"
         sql += f" ORDER BY {order_by}"
         if limit is not None:
             sql += " LIMIT :limit"

--- a/saltapi/repository/pipt_repository.py
+++ b/saltapi/repository/pipt_repository.py
@@ -932,7 +932,7 @@ class PiptRepository:
                     "title": proposal["Title"],
                     "principal_investigator": proposal["PI_Surname"],
                     "editable": editable,
-                    "proposal_file": ProposalRepository.proposal_file_url(code),
+                    "proposal_file": ProposalRepository.proposal_file_url(code, phase),
                 }
             )
         return proposals_list

--- a/saltapi/repository/proposal_repository.py
+++ b/saltapi/repository/proposal_repository.py
@@ -303,7 +303,7 @@ LIMIT :limit;
             "requested_times": requested_times,
             "science_configurations": self._get_science_configurations(proposal_code),
             "phase1_proposal_summary": summary_url,
-            "proposal_file": ProposalRepository.proposal_file_url(proposal_code),
+            "proposal_file": ProposalRepository.proposal_file_url(proposal_code, phase),
         }
         return proposal
 
@@ -321,8 +321,8 @@ LIMIT :limit;
             raise NotFoundError()
 
     @staticmethod
-    def proposal_file_url(proposal_code: str) -> str:
-        return f"/proposals/{proposal_code}.zip"
+    def proposal_file_url(proposal_code: str, phase: int) -> str:
+        return f"/proposals/{proposal_code}.zip?phase={phase}"
 
     def _semesters(self, proposal_code: str) -> List[str]:
         """

--- a/saltapi/service/pipt_service.py
+++ b/saltapi/service/pipt_service.py
@@ -111,7 +111,7 @@ class PiptService:
         self,
         user: User,
         phase: Optional[int] = None,
-        limit: int = 250,
+        limit: Optional[int] = None,
         descending: bool = False,
     ) -> List[Dict[str, Any]]:
         """

--- a/saltapi/service/pipt_service.py
+++ b/saltapi/service/pipt_service.py
@@ -110,7 +110,7 @@ class PiptService:
     def get_proposals(
         self,
         user: User,
-        phase: Optional[int] = None,
+        phase: int,
         limit: Optional[int] = None,
         descending: bool = True,
     ) -> List[Dict[str, Any]]:

--- a/saltapi/service/pipt_service.py
+++ b/saltapi/service/pipt_service.py
@@ -112,7 +112,7 @@ class PiptService:
         user: User,
         phase: Optional[int] = None,
         limit: Optional[int] = None,
-        descending: bool = False,
+        descending: bool = True,
     ) -> List[Dict[str, Any]]:
         """
         Fetch proposals, optionally filtered by phase.

--- a/saltapi/web/api/pipt.py
+++ b/saltapi/web/api/pipt.py
@@ -273,7 +273,7 @@ def get_block_visits(
     response_model=List[PiptProposal],
 )
 def get_pipt_proposals(
-    phase: Literal[1, 2] = Query(..., description="Proposal phase"),
+    phase: int = Query(..., description="Proposal phase"),
     limit: Optional[int] = Query(None, description="Max number of proposals"),
     descending: bool = Query(True, description="Sort in descending order"),
     user: User = Depends(get_current_user),

--- a/saltapi/web/api/pipt.py
+++ b/saltapi/web/api/pipt.py
@@ -274,7 +274,7 @@ def get_block_visits(
 )
 def get_pipt_proposals(
     phase: Optional[int] = Query(None, description="Phase filter"),
-    limit: int = Query(250, description="Max number of proposals"),
+    limit: Optional[int] = Query(None, description="Max number of proposals"),
     descending: bool = Query(False, description="Sort in descending order"),
     user: User = Depends(get_current_user),
 ):

--- a/saltapi/web/api/pipt.py
+++ b/saltapi/web/api/pipt.py
@@ -275,7 +275,7 @@ def get_block_visits(
 def get_pipt_proposals(
     phase: Optional[int] = Query(None, description="Phase filter"),
     limit: Optional[int] = Query(None, description="Max number of proposals"),
-    descending: bool = Query(False, description="Sort in descending order"),
+    descending: bool = Query(True, description="Sort in descending order"),
     user: User = Depends(get_current_user),
 ):
     with UnitOfWork() as unit_of_work:

--- a/saltapi/web/api/pipt.py
+++ b/saltapi/web/api/pipt.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Literal, Optional
 
 from fastapi import APIRouter, Depends, Query
 
@@ -273,7 +273,7 @@ def get_block_visits(
     response_model=List[PiptProposal],
 )
 def get_pipt_proposals(
-    phase: Optional[int] = Query(None, description="Phase filter"),
+    phase: Literal[1, 2] = Query(..., description="Proposal phase"),
     limit: Optional[int] = Query(None, description="Max number of proposals"),
     descending: bool = Query(True, description="Sort in descending order"),
     user: User = Depends(get_current_user),

--- a/saltapi/web/schema/pipt.py
+++ b/saltapi/web/schema/pipt.py
@@ -384,16 +384,8 @@ class PiptProposal(BaseModel):
     )
     proposal_code: str = Field(..., title="Proposal code", description="Proposal code")
     title: str = Field(..., title="Title", description="Proposal title")
-    semester: Semester = Field(
-        ...,
-        title="Semester",
-        description="Semester for which the proposal details are given",
-    )
     principal_investigator: str = Field(
         ..., title="Principal Investigator", description="Principal Investigator"
-    )
-    semester: Semester = Field(
-        ..., title="Semester", description="Semester for which the time is requested"
     )
     editable: bool = Field(
         ...,


### PR DESCRIPTION
This PR makes various changes to the `/pipt/proposals/` endpoint:

* The n+1 problem for the database queries is addressed; no queries for individual proposals are made any longer.
* There is no default limit on the number of returned proposals, as the endpoint is faster now.
* The semester has been dropped.
* The results are sorted in descending order by default.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/salt-api/403)
<!-- Reviewable:end -->
