### PR TITLE
Handle missing proposal code in XML

### DIFF
--- a/saltapi/web/api/submissions.py
+++ b/saltapi/web/api/submissions.py
@@ -74,7 +74,7 @@ async def create_submission(
         f"the proposal code in the submitted XML ({xml_proposal_code})."
     )
     if proposal_code is not None:
-        if xml_proposal_code != proposal_code:
+        if xml_proposal_code and xml_proposal_code != proposal_code:
             raise ValueError(message)
     else:
         if xml_proposal_code and not xml_proposal_code.startswith("Unsubmitted"):


### PR DESCRIPTION
There will be no proposal code in the XML for block submissions.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/saltastroops/salt-api/432)
<!-- Reviewable:end -->
